### PR TITLE
Tokenizer rewrite

### DIFF
--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -1,255 +1,255 @@
 module.exports = function(src, opts){
-    opts = opts || {};
+    opts = opts || {}; // unused
 
-    var r = [];
-
-    var c;
-    var next_is_escaped;
-
+    var tokens = [];
     var beesting_stack = [];
+    var buff = ""; // modified by pushTok and addToBuffer
+    var peek;
 
-    var buff = "";
-    var i = 0;
-    var next_loc = 0;
+    var next_loc = 0; // only for pushTok
 
-    var pushTok = function(type){
-        var loc = {start: next_loc, end: next_loc + buff.length};
-        r.push({
-            type: type,
-            src: buff,
+    var pushTok = function(value, name){
+        var loc = {start: next_loc, end: next_loc + value.length};
+
+        tokens.push({
+            type: name,
+            src: value,
             loc: loc
         });
+
         next_loc = loc.end;
         buff = "";
     };
-    var ctxChange = function(){
-        if(buff.length > 0){
-            pushTok("RAW");
-        }
-        buff = c;
+
+    var i = 0;
+    var c = src[0];
+
+    var advance = function(n){
+        i += n;
+        c = src[i];
     };
 
+    // loop invariant: c = src[i] follows the last character buff contained
+    var addToBuffer = function(stopCond, doEscaping){
+        var escaped = false;
+        while(i < src.length && (!stopCond() || escaped)){
+            if(escaped){
+                escaped = false;
+            }else if(doEscaping){
+                escaped = c === "\\";
+            }
+
+            buff += c;
+            advance(1);
+        }
+    };
+
+    var handleChevronBody = function(){
+        addToBuffer(function(){
+            peek = src.substring(i, i + 2);
+            return peek === "#{" || peek === ">>";
+        }, true);
+
+        if(buff.length > 0){
+            pushTok(buff, "CHEVRON-STRING");
+        }
+
+        if(peek === "#{"){
+            pushTok("#{", "CHEVRON-BEESTING-OPEN");
+            beesting_stack.push({curly_count: 0});
+        }else if(peek === ">>"){
+            pushTok(">>", "CHEVRON-CLOSE");
+        }
+
+        advance(2);
+    };
+
+    var raw_toks = [
+        "<=>",
+        "<=",
+        "<",
+        "||",
+        "|",
+        "==",
+        "=>",
+        "=",
+        ":=",
+        ":",
+        ">=",
+        "><",
+        ">",
+        "&&",
+        "!=",
+        "(",
+        ")",
+        "{",
+        "}",
+        "[",
+        "]",
+        ",",
+        "/",
+        ".",
+        "-",
+        "%",
+        "+",
+        ";",
+        "*",
+    ];
+
     while(i < src.length){
-        c = src[i];
+        if(/\s/.test(c)){
+            addToBuffer(function(){
+                return !/\s/.test(c);
+            });
 
-        ///////////////////////////////////////////////////////////////////////////
-        //whitespace
-        if(/^\s$/.test(c)){
-            ctxChange();
-            while(i < src.length){
-                c = src[i];
-                if(!/^\s$/.test(src[i + 1])){
-                    break;
-                }
-                buff += c;
-                i++;
-            }
-            pushTok("WHITESPACE");
+            pushTok(buff, "WHITESPACE");
 
-        ///////////////////////////////////////////////////////////////////////////
-        //string
-        }else if(c === "\""){
-            ctxChange();
-            i++;
-            next_is_escaped = false;
-            while(i < src.length){
-                c = src[i];
-                buff += c;
-                if(next_is_escaped){
-                    next_is_escaped = false;
+            continue;
+        }
+        if(c === "/"){
+            peek = src[i + 1];
+            if(peek === "/"){
+                addToBuffer(function(){
+                    return c === "\n" || c === "\r";
+                });
+
+                if(i < src.length){
+                    pushTok(buff + c, "LINE-COMMENT");
+                    advance(1);
                 }else{
-                    if(c === "\\"){
-                        next_is_escaped = true;
-                    }
-                    if(c === "\""){
-                        break;
-                    }
+                    pushTok(buff, "LINE-COMMENT");
                 }
-                i++;
-            }
-            pushTok("STRING");
 
-        ///////////////////////////////////////////////////////////////////////////
-        //chevron
-        }else if(false
-                || (c === "<" && (src[i + 1] === "<"))
-                || (c === "}" && (beesting_stack.length > 0) && (beesting_stack[beesting_stack.length-1].curly_count === 0))
-                ){
-            ctxChange();
-            if(c === "}" && beesting_stack.length > 0){
-                pushTok("CHEVRON-BEESTING-CLOSE");
-                i++;
-                beesting_stack.pop();
+                continue;
+            }
+            if(peek === "*"){
+                addToBuffer(function(){
+                    return c === "*" && src[i + 1] === "/"
+                           && buff.length > 1; // '/*/' isn't valid
+                });
+
+                if(i < src.length){
+                    pushTok(buff + "*/", "BLOCK-COMMENT");
+                    advance(2);
+                }else{
+                    pushTok(buff, "RAW-ILLEGAL");
+                }
+
+                continue;
+            }
+
+            // fallthrough
+        }
+        if(/[0-9]/.test(c)){
+            addToBuffer(function(){
+                return !/[0-9]/.test(c);
+            });
+
+            if(c !== "." || !/[0-9]/.test(src[i + 1])){
+                pushTok(buff, "NUMBER");
+                continue;
+            }
+
+            // fallthrough
+        }
+        if(c === "." && /[0-9]/.test(src[i + 1])){
+            buff += ".";
+            advance(1);
+
+            addToBuffer(function(){
+                return !/[0-9]/.test(c);
+            });
+
+            pushTok(buff, "NUMBER");
+            continue;
+        }
+        if(c === '"'){
+            addToBuffer(function(){
+                return c === '"' && buff.length > 0;
+            }, true);
+
+            if(i < src.length){
+                pushTok(buff + '"', "STRING");
+                advance(1);
             }else{
-                buff = src.substring(i, i + 2);
-                i += 2;
-                pushTok("CHEVRON-OPEN");
-            }
-            next_is_escaped = false;
-            while(i < src.length){
-                c = src[i];
-                if(next_is_escaped){
-                    next_is_escaped = false;
-                }else{
-                    if(c === "\\"){
-                        next_is_escaped = true;
-                    }
-                    if(c === ">" && (src[i + 1] === ">")){
-                        if(buff.length > 0){
-                            pushTok("CHEVRON-STRING");
-                        }
-                        buff = src.substring(i, i + 2);
-                        i += 1;
-                        pushTok("CHEVRON-CLOSE");
-                        break;
-                    }
-                    if(c === "#" && (src[i + 1] === "{")){
-                        if(buff.length > 0){
-                            pushTok("CHEVRON-STRING");
-                        }
-                        buff = src.substring(i, i + 2);
-                        i += 1;
-                        pushTok("CHEVRON-BEESTING-OPEN");
-                        beesting_stack.push({curly_count: 0});
-                        break;
-                    }
-                }
-                buff += c;
-                i++;
+                pushTok(buff, "RAW-ILLEGAL");
             }
 
-        ///////////////////////////////////////////////////////////////////////////
-        //number
-        }else if(/^[0-9]$/.test(c) || (c === "." && /^[0-9]$/.test(src[i + 1]))){
-            ctxChange();
-            buff = "";
-            var has_seen_decimal = c === ".";
-            while(i < src.length){
-                c = src[i];
-                buff += c;
-                if(!/^[0-9]$/.test(src[i + 1])){
-                    if(src[i+1] === "." && !has_seen_decimal){
-                        has_seen_decimal = true;
-                    }else{
-                        break;
-                    }
-                }
-                i++;
-            }
-            if(buff[buff.length - 1] === "."){
-                buff = buff.substring(0, buff.length - 1);
-                pushTok("NUMBER");
-                buff = ".";
+            continue;
+        }
+        if(c === "r" && src.substring(i + 1, i + 3) === "e#"){
+            addToBuffer(function(){
+                return c === "#" && buff.length > 2;
+            }, true);
+
+            peek = src.substring(i + 1, i + 3);
+            if(peek === "gi" || peek === "ig"){
+                pushTok(buff + "#" + peek, "REGEXP");
+                advance(3);
+            }else if(peek[0] === "i" || peek[0] === "g"){
+                pushTok(buff + "#" + peek[0], "REGEXP");
+                advance(2);
+            }else if(i < src.length){
+                pushTok(buff + "#", "REGEXP");
+                advance(1);
             }else{
-                pushTok("NUMBER");
+                pushTok(buff, "RAW-ILLEGAL");
             }
 
-        ///////////////////////////////////////////////////////////////////////////
-        //regexp
-        }else if(c === "r" && src[i+1] === "e" && src[i+2] === "#"){
-            ctxChange();
-            buff = src.substring(i, i + 3);
-            i += 3;
-            next_is_escaped = false;
-            while(i < src.length){
-                c = src[i];
-                buff += c;
-                if(next_is_escaped){
-                    next_is_escaped = false;
+            continue;
+        }
+        if(c === "<" && src[i + 1] === "<"){
+            pushTok("<<", "CHEVRON-OPEN");
+            advance(2);
+
+            handleChevronBody();
+
+            continue;
+        }
+        if(/[a-zA-Z_$]/.test(c)){
+            addToBuffer(function(){
+                return !/[a-zA-Z0-9_$]/.test(c);
+            });
+
+            pushTok(buff, "SYMBOL");
+            continue;
+        }
+
+        if(beesting_stack.length > 0){
+            if(c === "{"){
+                beesting_stack[beesting_stack.length-1].curly_count++;
+            }else if(c === "}"){
+                if(beesting_stack[beesting_stack.length-1].curly_count === 0){
+                    pushTok("}", "CHEVRON-BEESTING-CLOSE");
+                    advance(1);
+                    beesting_stack.pop();
+
+                    handleChevronBody();
+
+                    continue;
                 }else{
-                    if(c === "\\"){
-                        next_is_escaped = true;
-                    }
-                    if(c === "#"){
-                        if(src[i + 1] === "i"){
-                            i++;
-                            c = src[i];
-                            buff += c;
-                            if(src[i + 1] === "g"){
-                                i++;
-                                c = src[i];
-                                buff += c;
-                            }
-                        }else if(src[i + 1] === "g"){
-                            i++;
-                            c = src[i];
-                            buff += c;
-                            if(src[i + 1] === "i"){
-                                i++;
-                                c = src[i];
-                                buff += c;
-                            }
-                        }
-                        break;
-                    }
-                }
-                i++;
-            }
-            pushTok("REGEXP");
-
-        ///////////////////////////////////////////////////////////////////////////
-        //symbol
-        }else if(/^[a-zA-Z_$]$/.test(c)){
-            ctxChange();
-            buff = "";
-            while(i < src.length){
-                c = src[i];
-                buff += c;
-                if(!/^[a-zA-Z0-9_$]$/.test(src[i + 1])){
-                    break;
-                }
-                i++;
-            }
-            pushTok("SYMBOL");
-
-        ///////////////////////////////////////////////////////////////////////////
-        //line-comment
-        }else if(c === "/" && (src[i + 1] === "/")){
-            ctxChange();
-            i++;
-            while(i < src.length){
-                c = src[i];
-                buff += c;
-                if(c === "\n" || c === "\r"){
-                    break;
-                }
-                i++;
-            }
-            pushTok("LINE-COMMENT");
-
-        ///////////////////////////////////////////////////////////////////////////
-        //block-comment
-        }else if(c === "/" && (src[i + 1] === "*")){
-            ctxChange();
-            i++;
-            while(i < src.length){
-                c = src[i];
-                buff += c;
-                if(c === "/" && (src[i-1] === "*")){
-                    break;
-                }
-                i++;
-            }
-            pushTok("BLOCK-COMMENT");
-
-        ///////////////////////////////////////////////////////////////////////////
-        //raw
-        }else if("(){}[];".indexOf(c) >= 0){//single char groups
-            ctxChange();
-            pushTok("RAW");
-            if(beesting_stack.length > 0){
-                if(c === "{"){
-                    beesting_stack[beesting_stack.length-1].curly_count++;
-                }else if(c === "}"){
                     beesting_stack[beesting_stack.length-1].curly_count--;
                 }
             }
-        }else{
-            buff += c;
         }
-        i++;
-    }
-    ctxChange();
 
-    return r;
+        var tok = 0;
+        var l = [c, c + src[i + 1], src.substring(i, i + 3)]; // lookahead
+
+        while(tok < raw_toks.length){
+            if(raw_toks[tok] === l[raw_toks[tok].length-1]){
+                pushTok(raw_toks[tok], "RAW");
+                advance(raw_toks[tok].length);
+                break;
+            }
+            tok++;
+        }
+
+        if(tok === raw_toks.length){
+            pushTok(c, "RAW-ILLEGAL");
+            advance(1);
+        }
+    }
+
+    return tokens;
 };

--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -132,7 +132,7 @@ module.exports = function(src){
                     pushTok(buff + "*/", "BLOCK-COMMENT");
                     advance(2);
                 }else{
-                    pushTok(buff, "RAW-ILLEGAL");
+                    pushTok(buff, "ILLEGAL");
                 }
 
                 continue;
@@ -172,7 +172,7 @@ module.exports = function(src){
                 pushTok(buff + '"', "STRING");
                 advance(1);
             }else{
-                pushTok(buff, "RAW-ILLEGAL");
+                pushTok(buff, "ILLEGAL");
             }
 
             continue;
@@ -193,7 +193,7 @@ module.exports = function(src){
                 pushTok(buff + "#", "REGEXP");
                 advance(1);
             }else{
-                pushTok(buff, "RAW-ILLEGAL");
+                pushTok(buff, "ILLEGAL");
             }
 
             continue;
@@ -245,7 +245,7 @@ module.exports = function(src){
         }
 
         if(tok === raw_toks.length){
-            pushTok(c, "RAW-ILLEGAL");
+            pushTok(c, "ILLEGAL");
             advance(1);
         }
     }

--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -1,28 +1,59 @@
-module.exports = function(src, opts){
-    opts = opts || {}; // unused
+var raw_toks = [
+    "<=>",
+    "<=",
+    "<",
+    "||",
+    "|",
+    "==",
+    "=>",
+    "=",
+    ":=",
+    ":",
+    ">=",
+    "><",
+    ">",
+    "&&",
+    "!=",
+    "(",
+    ")",
+    "{",
+    "}",
+    "[",
+    "]",
+    ",",
+    "/",
+    ".",
+    "-",
+    "%",
+    "+",
+    ";",
+    "*",
+];
+
+module.exports = function(src){
 
     var tokens = [];
     var beesting_stack = [];
     var buff = ""; // modified by pushTok and addToBuffer
     var peek;
-
-    var next_loc = 0; // only for pushTok
-
-    var pushTok = function(value, name){
-        var loc = {start: next_loc, end: next_loc + value.length};
-
-        tokens.push({
-            type: name,
-            src: value,
-            loc: loc
-        });
-
-        next_loc = loc.end;
-        buff = "";
-    };
-
     var i = 0;
     var c = src[0];
+
+    var pushTok = (function(){
+        var next_loc = 0;
+        return function(value, name){
+            var loc = {start: next_loc, end: next_loc + value.length};
+
+            tokens.push({
+                type: name,
+                src: value,
+                loc: loc
+            });
+
+            next_loc = loc.end;
+            buff = "";
+        };
+    }());
 
     var advance = function(n){
         i += n;
@@ -64,37 +95,6 @@ module.exports = function(src, opts){
         advance(2);
     };
 
-    var raw_toks = [
-        "<=>",
-        "<=",
-        "<",
-        "||",
-        "|",
-        "==",
-        "=>",
-        "=",
-        ":=",
-        ":",
-        ">=",
-        "><",
-        ">",
-        "&&",
-        "!=",
-        "(",
-        ")",
-        "{",
-        "}",
-        "[",
-        "]",
-        ",",
-        "/",
-        ".",
-        "-",
-        "%",
-        "+",
-        ";",
-        "*",
-    ];
 
     while(i < src.length){
         if(/\s/.test(c)){
@@ -234,10 +234,9 @@ module.exports = function(src, opts){
         }
 
         var tok = 0;
-        var l = [c, c + src[i + 1], src.substring(i, i + 3)]; // lookahead
 
         while(tok < raw_toks.length){
-            if(raw_toks[tok] === l[raw_toks[tok].length-1]){
+            if(raw_toks[tok] === src.substring(i, i + raw_toks[tok].length)){
                 pushTok(raw_toks[tok], "RAW");
                 advance(raw_toks[tok].length);
                 break;

--- a/tests/tokenizer.test.js
+++ b/tests/tokenizer.test.js
@@ -4,7 +4,7 @@ var tokenizer = require("../src/tokenizer");
 
 test("tokenizer", function(t){
 
-    var tst = function(src, expected){
+    var tst = function(src, expected){ // prints 'equivalent' after each test
         var tokens = tokenizer(src);
         _.each(tokens, function(tok){
             //assert the loc is right
@@ -159,6 +159,35 @@ test("tokenizer", function(t){
         "[SYMBOL]z",
     ]);
 
+    tst('{"":-6}', [
+        "[RAW]{",
+        '[STRING]""',
+        "[RAW]:",
+        "[RAW]-",
+        "[NUMBER]6",
+        "[RAW]}",
+    ]);
+    tst("[3,-4+-x]", [
+        "[RAW][",
+        "[NUMBER]3",
+        "[RAW],",
+        "[RAW]-",
+        "[NUMBER]4",
+        "[RAW]+",
+        "[RAW]-",
+        "[SYMBOL]x",
+        "[RAW]]",
+    ]);
+    tst("fn(-_A,-.2)", [
+        "[SYMBOL]fn",
+        "[RAW](",
+        "[RAW]-",
+        "[SYMBOL]_A",
+        "[RAW],",
+        "[RAW]-",
+        "[NUMBER].2",
+        "[RAW])",
+    ]);
 
     tst("re#regex#", [
         "[REGEXP]re#regex#",

--- a/tests/tokenizer.test.js
+++ b/tests/tokenizer.test.js
@@ -4,7 +4,7 @@ var tokenizer = require("../src/tokenizer");
 
 test("tokenizer", function(t){
 
-    var tst = function(src, expected){ // prints 'equivalent' after each test
+    var tst = function(src, expected){
         var tokens = tokenizer(src);
         _.each(tokens, function(tok){
             //assert the loc is right
@@ -239,6 +239,29 @@ test("tokenizer", function(t){
         "[RAW]{",
         "[RAW]}",
         "[RAW]}",
+    ]);
+
+    tst("/*/", ["[RAW-ILLEGAL]/*/"]);
+    tst("/**/", ["[BLOCK-COMMENT]/**/"]);
+
+    tst("\"one", ["[RAW-ILLEGAL]\"one"]);
+    tst("re#one", ["[RAW-ILLEGAL]re#one"]);
+
+    tst("a&&b", [
+        "[SYMBOL]a",
+        "[RAW]&&",
+        "[SYMBOL]b",
+    ]);
+
+    tst("&&&", [
+        "[RAW]&&",
+        "[RAW-ILLEGAL]&",
+    ]);
+
+    tst(".λ,", [
+        "[RAW].",
+        "[RAW-ILLEGAL]λ",
+        "[RAW],",
     ]);
 
     t.end();

--- a/tests/tokenizer.test.js
+++ b/tests/tokenizer.test.js
@@ -241,11 +241,11 @@ test("tokenizer", function(t){
         "[RAW]}",
     ]);
 
-    tst("/*/", ["[RAW-ILLEGAL]/*/"]);
+    tst("/*/", ["[ILLEGAL]/*/"]);
     tst("/**/", ["[BLOCK-COMMENT]/**/"]);
 
-    tst("\"one", ["[RAW-ILLEGAL]\"one"]);
-    tst("re#one", ["[RAW-ILLEGAL]re#one"]);
+    tst("\"one", ["[ILLEGAL]\"one"]);
+    tst("re#one", ["[ILLEGAL]re#one"]);
 
     tst("a&&b", [
         "[SYMBOL]a",
@@ -255,12 +255,12 @@ test("tokenizer", function(t){
 
     tst("&&&", [
         "[RAW]&&",
-        "[RAW-ILLEGAL]&",
+        "[ILLEGAL]&",
     ]);
 
     tst(".λ,", [
         "[RAW].",
-        "[RAW-ILLEGAL]λ",
+        "[ILLEGAL]λ",
         "[RAW],",
     ]);
 


### PR DESCRIPTION
Passes all tests, including 3 new tokenizer tests and a few manual compilation tests. Fixes https://github.com/Picolab/pico-engine/issues/205 and https://github.com/Picolab/pico-engine/issues/153. Differentiates between RAW and the new RAW-ILLEGAL token, which by definition isn't in the grammar.

I hope a rewrite is okay. I had trouble fixing the old code, and the new code is a bit shorter considering the raw token list. I tried to follow a good semantic spacing style.

The raw token code I tried before wouldn't match `&&`, which is valid even though `&` isn't.